### PR TITLE
fix relative path issue while create new banner with non-default media source

### DIFF
--- a/assets/components/bannery/js/mgr/widgets/banners.grid.js
+++ b/assets/components/bannery/js/mgr/widgets/banners.grid.js
@@ -356,7 +356,7 @@ Bannery.window.Ad = function(config) {
 							,openTo: config.openTo || '/'
 							,listeners: {
 								select: {fn:function(data) {
-									Ext.getCmp('currimg').setSrc(data.fullRelativeUrl);
+									Ext.getCmp('currimg').setSrc(data.relativeUrl);
 									Ext.getCmp('image').setValue(data.relativeUrl);
 								}}
 								,change: {fn:function(data) {


### PR DESCRIPTION
При создании нового баннера phpthumb не показывает превью добавленного изображения потому что стоит полный путь, хотя в запросе передается источник файлов ( например генерируется путь "assets/other_files/banners/slider.jpg&w=166&h=200&f=jpg&q=90&HTTP_MODAUTH=modx53d2461933a048.66754502_953f5f468cc8818.07094850&far=1&wctx=mgr&source=3", несмотря на то, что для источника файлов "3" все пути относительные идут от папки "assets/other_files" ) - все это актуально если используется источник файлов отличный от дефолтного, потому что у дефолтного пути все равно полные, а вот на относительных phpthumbof дает сбой.