### PR TITLE
Do not process image link (from media source) if no image is specified

### DIFF
--- a/core/components/bannery/elements/snippets/snippet.bannery.php
+++ b/core/components/bannery/elements/snippets/snippet.bannery.php
@@ -106,7 +106,7 @@ foreach ($rows as $row) {
 		$source = $sources[$row['source']];
 	}
 
-	if (!empty($source) && $source instanceof modMediaSource) {
+	if (!empty($source) && $source instanceof modMediaSource && !empty($row['image'])) {
 		$row['image'] = $source->getObjectUrl($row['image']);
 	}
 


### PR DESCRIPTION
This prevents processing the media source URL (if no image is specified) and should allow us to make some check on the `image` placeholder