### PR TITLE
Fixes to handle non standard media sources

### DIFF
--- a/assets/components/bannery/js/mgr/widgets/banners.grid.js
+++ b/assets/components/bannery/js/mgr/widgets/banners.grid.js
@@ -356,12 +356,12 @@ Bannery.window.Ad = function(config) {
 							,openTo: config.openTo || '/'
 							,listeners: {
 								select: {fn:function(data) {
-									Ext.getCmp('currimg').setSrc(data.fullRelativeUrl);
+                                    Ext.getCmp('currimg').setSrc(data.url, Ext.getCmp('modx-combo-source').getValue());
 									Ext.getCmp('image').setValue(data.relativeUrl);
 								}}
 								,change: {fn:function(data) {
 									var value = this.getValue();
-									Ext.getCmp('currimg').setSrc(value);
+									Ext.getCmp('currimg').setSrc(value, Ext.getCmp('modx-combo-source').getValue());
 									Ext.getCmp('image').setValue(value);
 								}}
 							}

--- a/core/components/bannery/model/bannery/byad.class.php
+++ b/core/components/bannery/model/bannery/byad.class.php
@@ -11,7 +11,8 @@ class byAd extends xPDOSimpleObject {
 			/** @var modMediaSource $source */
 			if ($source = $this->xpdo->getObject('sources.modMediaSource', $source)) {
 				$source->initialize();
-				$image = $source->getObjectUrl($image);
+				//$image = $source->getObjectUrl($image);
+				$image = $source->getBasePath($image) . $image;
 			}
 		}
 


### PR DESCRIPTION
### What does it do ?

Basically it sets the images "relative path" (relative to the media source it belongs to), and pass the used media source to `Ext.ux.Image::setSrc` to that phpthumb is able to compute the appropriate URL within the manager.

### Why is it needed ?

When using a media source other than "filesystem" (the media source could have its own (sub)domain), images URLs are wrong (at least inside the manager), resulting in no preview/thumb available/404 errors.

### Related issue(s)/PR(s)

* somehow related to #11 (if Google Translate did its job ^^)
