### PR TITLE
Allow uppercase file extension to be rendered in grid

### DIFF
--- a/assets/components/bannery/js/mgr/widgets/home.panel.js
+++ b/assets/components/bannery/js/mgr/widgets/home.panel.js
@@ -286,7 +286,7 @@ Bannery.renderGridImage = function(img) {
 		: 40;
 
 	if (img.length > 0) {
-		if (!/(jpg|jpeg|png|gif|bmp)$/.test(img)) {
+		if (!/(jpg|jpeg|png|gif|bmp)$/.test(img.toLowerCase())) {
 			return img;
 		}
 		else if (/^(http|https)/.test(img)) {


### PR DESCRIPTION
### What does it do ?

Use lowercase file names in `Bannery.renderGridImage`.

### Why is it needed ?

An image file with an uppercase extension (ie. `file.JPG`) is not rendered (its path is displayed instead).